### PR TITLE
フッターメニューボタンのフォーカス枠線削除とセーフエリア対応

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,10 @@
 *.yaml text eol=lf
 *.md text eol=lf
 *.toml text eol=lf
+*.css text eol=lf
+*.scss text eol=lf
+*.sass text eol=lf
+*.html text eol=lf
 
 # Declare files that will always have LF line endings on checkout
 *.sh text eol=lf

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Tauri + React + Typescript</title>
   </head>
 

--- a/src/components/layout/ResponsiveLayout/ResponsiveLayout.tsx
+++ b/src/components/layout/ResponsiveLayout/ResponsiveLayout.tsx
@@ -2,6 +2,7 @@ import { AppShell } from "@mantine/core";
 import { memo, useId, useMemo } from "react";
 import { FooterNavigation, HamburgerMenu, HeaderNavigation, SideNavigation } from "./components";
 import { useNavigationConfig, useResponsiveLayout } from "./hooks";
+import safeAreaStyles from "./safeArea.module.css";
 import type { NavigationItem, ResponsiveLayoutProps, UseResponsiveLayoutReturn } from "./types";
 
 // 【ユーティリティ関数】: NavigationItem配列をgroupedItems形式に変換
@@ -70,21 +71,29 @@ const ResponsiveLayout = memo<ResponsiveLayoutProps>(({ children, navigationConf
   );
 
   return (
-    <div data-testid="responsive-layout-container">
+    <div data-testid="responsive-layout-container" className={safeAreaStyles.safeAreaContainer}>
       <AppShell
-        header={{ height: { base: 56, md: 64 } }}
+        header={{
+          height: {
+            base: "var(--header-height-mobile)",
+            md: "var(--header-height-desktop)",
+          },
+        }}
         navbar={{
           width: { base: 0, md: 280 },
           breakpoint: "md",
           collapsed: { mobile: true, desktop: false },
         }}
         footer={{
-          height: { base: 80, md: 0 },
+          height: {
+            base: "var(--footer-height-mobile)",
+            md: 0,
+          },
         }}
         padding={{ base: "sm", md: "md" }}
       >
-        {/* ヘッダー部分 */}
-        <AppShell.Header>
+        {/* ヘッダー部分 - env()セーフエリア適用 */}
+        <AppShell.Header className={safeAreaStyles.safeAreaHeader}>
           <HeaderNavigation
             items={safeNavigationConfig.primary}
             isMobile={isMobile}
@@ -93,9 +102,9 @@ const ResponsiveLayout = memo<ResponsiveLayoutProps>(({ children, navigationConf
           />
         </AppShell.Header>
 
-        {/* デスクトップサイドバー */}
+        {/* デスクトップサイドバー - env()セーフエリア適用 */}
         {!isMobile && (
-          <AppShell.Navbar>
+          <AppShell.Navbar className={safeAreaStyles.safeAreaSidebar}>
             <SideNavigation
               items={safeNavigationConfig.secondary}
               groupedItems={groupedSecondaryItems}
@@ -103,15 +112,17 @@ const ResponsiveLayout = memo<ResponsiveLayoutProps>(({ children, navigationConf
           </AppShell.Navbar>
         )}
 
-        {/* モバイルフッター */}
+        {/* モバイルフッター - env()セーフエリア適用 */}
         {isMobile && (
-          <AppShell.Footer>
+          <AppShell.Footer className={safeAreaStyles.safeAreaFooter}>
             <FooterNavigation items={safeNavigationConfig.primary} />
           </AppShell.Footer>
         )}
 
-        {/* メインコンテンツ */}
-        <AppShell.Main id={mainContentId}>{children}</AppShell.Main>
+        {/* メインコンテンツ - env()セーフエリア適用 */}
+        <AppShell.Main id={mainContentId} className={safeAreaStyles.safeAreaMain}>
+          {children}
+        </AppShell.Main>
 
         {/* モバイルハンバーガーメニュー */}
         <HamburgerMenu

--- a/src/components/layout/ResponsiveLayout/components/FooterNavigation.tsx
+++ b/src/components/layout/ResponsiveLayout/components/FooterNavigation.tsx
@@ -105,6 +105,7 @@ export const FooterNavigation = memo<FooterNavigationProps>(({ items }) => {
       boxSizing: "border-box" as const,
       backgroundColor: isActive ? "var(--mantine-color-blue-light)" : "transparent",
       color: isActive ? "var(--mantine-color-blue-filled)" : "inherit",
+      outline: "none",
     }),
     []
   );

--- a/src/components/layout/ResponsiveLayout/safeArea.module.css
+++ b/src/components/layout/ResponsiveLayout/safeArea.module.css
@@ -1,0 +1,53 @@
+/* セーフエリア対応 - コンテンツサイズを保持しつつ安全な配置 */
+.safeAreaContainer {
+  min-height: 100dvh; /* dynamic viewport height対応 */
+
+  /* AppShell用のCSS変数を定義 */
+  --header-height-mobile: calc(56px + env(safe-area-inset-top, 0px));
+  --header-height-desktop: calc(64px + env(safe-area-inset-top, 0px));
+  --footer-height-mobile: calc(80px + env(safe-area-inset-bottom, 0px));
+}
+
+/* ヘッダー: 高さを拡張してセーフエリア分も含める */
+.safeAreaHeader {
+  /* パディングではなく高さを拡張 */
+  min-height: calc(56px + env(safe-area-inset-top));
+  padding-top: env(safe-area-inset-top);
+  box-sizing: border-box;
+
+  /* コンテンツは下部に配置 */
+  display: flex;
+  align-items: flex-end;
+}
+
+/* モバイル用のヘッダー高さ調整 */
+@media screen and (min-width: 62em) {
+  .safeAreaHeader {
+    min-height: calc(64px + env(safe-area-inset-top));
+  }
+}
+
+/* フッター: 高さを拡張してセーフエリア分も含める */
+.safeAreaFooter {
+  min-height: calc(80px + env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
+  box-sizing: border-box;
+
+  /* コンテンツは上部に配置 */
+  display: flex;
+  align-items: flex-start;
+}
+
+/* サイドバーのセーフエリア対応 */
+.safeAreaSidebar {
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+  box-sizing: border-box;
+}
+
+/* メインコンテンツのセーフエリア対応 */
+.safeAreaMain {
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- フッターナビゲーションボタンのフォーカス時の青い枠線を削除
- セーフエリア（notch対応）の改善を同時適用
- ユーザーエクスペリエンスの向上

## Changes
- `FooterNavigation.tsx`: `outline: "none"` を追加してフォーカス枠線を削除
- `ResponsiveLayout.tsx`: セーフエリア対応のCSSクラスを適用
- `safeArea.module.css`: セーフエリア対応スタイルを新規作成
- `index.html`: viewport-fit=cover を追加

## Test plan
- [ ] フッターメニューボタンをタップ/クリックしてフォーカス枠線が表示されないことを確認
- [ ] モバイル端末（特にnotch付き端末）でセーフエリアが適切に機能することを確認
- [ ] 既存のナビゲーション機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)