### PR TITLE
fix(sessions): prevent session card right-side elements from wrapping

### DIFF
--- a/src/features/sessions/components/SessionList.tsx
+++ b/src/features/sessions/components/SessionList.tsx
@@ -123,7 +123,7 @@ export function SessionList({
                 </Group>
               </Stack>
               {/* Right: Profit/Loss (with EV below) / Duration */}
-              <Group gap="xs" wrap="nowrap">
+              <Group gap="xs" style={{ flexShrink: 0 }} wrap="nowrap">
                 <Stack align="flex-end" gap={0} style={{ lineHeight: 1.2 }}>
                   <Text
                     c={getProfitLossColor(session.profitLoss)}


### PR DESCRIPTION
## Summary
- セッション一覧ページのカードにおいて、右側の収支・EV・所要時間要素が折り返されるレイアウト不具合を修正
- 右側 `Group` に `flexShrink: 0` を追加し、常に1行で表示されるように変更
- 左側要素は既に `minWidth: 0` と `truncate` が設定済みのため、スペース不足時に適切に省略される

## Test plan
- [ ] モバイル幅（320px〜）で右側要素が折り返されないことを確認
- [ ] 大きな金額表示で右側要素が折り返されないことを確認
- [ ] デスクトップ幅で通常通り表示されることを確認
- [ ] カードのクリック・ルーティングが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)