### PR TITLE
fix(header): prevent page title wrapping, ensure right-side elements visible

### DIFF
--- a/src/components/layouts/AppShell.tsx
+++ b/src/components/layouts/AppShell.tsx
@@ -79,8 +79,8 @@ export function AppShell({ children }: AppShellProps) {
       padding={{ base: 'xs', sm: 'md' }}
     >
       <MantineAppShell.Header>
-        <Group h="100%" justify="space-between" px="md">
-          <Group>
+        <Group h="100%" justify="space-between" px="md" wrap="nowrap">
+          <Group style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
             <Burger
               aria-label="メニューを開く"
               hiddenFrom="sm"
@@ -92,10 +92,19 @@ export function AppShell({ children }: AppShellProps) {
               href="/dashboard"
               style={{ textDecoration: 'none', color: 'inherit' }}
             >
-              <Title order={3}>{pageTitle || 'Sapphire'}</Title>
+              <Title
+                order={3}
+                style={{
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {pageTitle || 'Sapphire'}
+              </Title>
             </Link>
           </Group>
-          <Group gap="sm">
+          <Group gap="sm" wrap="nowrap" style={{ flexShrink: 0 }}>
             {/* Active Session Indicator / Start Session Button */}
             {activeSession ? (
               <Tooltip


### PR DESCRIPTION
## Summary

ヘッダーのページタイトルが長い場合に折り返しが発生し、右側のセッションボタン・テーマ切替ボタンが押し出される問題を修正。

- ヘッダー外側 Group に `wrap="nowrap"` を追加し折り返しを禁止
- 左側 Group に `flex: 1, minWidth: 0, overflow: hidden` を適用し縮小可能に
- Title に `text-overflow: ellipsis` を適用し長いタイトルを省略表示
- 右側 Group に `flexShrink: 0` を適用し常に固定幅を確保

## Changed Tasks

1. ヘッダーの外側 Group に `wrap="nowrap"` を追加 (SAP-88)
2. 左側 Group にフレックスオーバーフロー制御を追加 (SAP-89)
3. Title にテキスト省略スタイルを追加 (SAP-90)
4. 右側 Group に flexShrink: 0 を追加 (SAP-91)
5. ビルド確認 (SAP-92)

## Test Plan

- [ ] 短いタイトルのページで、タイトル全文と右側要素がすべて表示されること
- [ ] 長いタイトルのページで、タイトルが省略記号（…）で切り詰められ、右側要素が押し出されないこと
- [ ] モバイル幅で、バーガーメニュー + タイトル + 右側要素が一行に収まること
- [ ] セッションボタン（LIVE/一時停止中/セッション）が常に表示されること
- [ ] テーマ切替ボタンが常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Linear: SAP-87