### PR TITLE
feat: multi-auth account linking

### DIFF
--- a/src/app/(main)/account/AccountContent.tsx
+++ b/src/app/(main)/account/AccountContent.tsx
@@ -1,0 +1,374 @@
+'use client'
+
+import {
+  Badge,
+  Button,
+  Container,
+  Group,
+  Modal,
+  Paper,
+  PasswordInput,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
+import {
+  IconBrandDiscord,
+  IconBrandGoogle,
+  IconLink,
+  IconLinkOff,
+  IconLock,
+  IconMail,
+} from '@tabler/icons-react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect, useState, useTransition } from 'react'
+
+import { usePageTitle } from '~/contexts/PageTitleContext'
+
+import { changePassword, setPassword, unlinkProvider } from './actions'
+
+interface LinkedProvider {
+  provider: string
+  providerAccountId: string
+}
+
+interface AccountContentProps {
+  linkedAccounts: {
+    providers: LinkedProvider[]
+    hasPassword: boolean
+  }
+}
+
+const PROVIDER_CONFIG = {
+  google: { label: 'Google', icon: IconBrandGoogle, color: 'red' },
+  discord: { label: 'Discord', icon: IconBrandDiscord, color: 'indigo' },
+} as const
+
+/**
+ * Account settings client component.
+ * Displays linked login methods and password management.
+ */
+export function AccountContent({ linkedAccounts }: AccountContentProps) {
+  usePageTitle('Account')
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [isPending, startTransition] = useTransition()
+
+  // Feedback from URL params
+  const [feedback, setFeedback] = useState<{
+    type: 'success' | 'error'
+    message: string
+  } | null>(null)
+
+  // Unlink confirmation modal
+  const [unlinkModalOpened, { open: openUnlinkModal, close: closeUnlinkModal }] =
+    useDisclosure(false)
+  const [providerToUnlink, setProviderToUnlink] = useState<string | null>(null)
+
+  // Password form state
+  const [passwordForm, setPasswordForm] = useState({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: '',
+    password: '',
+    confirmNewPassword: '',
+  })
+
+  useEffect(() => {
+    const linked = searchParams.get('linked')
+    const error = searchParams.get('error')
+    if (linked === 'success') {
+      setFeedback({ type: 'success', message: 'Account linked successfully' })
+      router.replace('/account')
+    } else if (error) {
+      setFeedback({ type: 'error', message: `Failed to link account: ${error}` })
+      router.replace('/account')
+    }
+  }, [searchParams, router])
+
+  const isProviderLinked = (provider: string) =>
+    linkedAccounts.providers.some((p) => p.provider === provider)
+
+  const handleUnlinkClick = (provider: string) => {
+    setProviderToUnlink(provider)
+    openUnlinkModal()
+  }
+
+  const handleUnlinkConfirm = () => {
+    if (!providerToUnlink) return
+    startTransition(async () => {
+      const result = await unlinkProvider(providerToUnlink)
+      if (result.success) {
+        setFeedback({ type: 'success', message: 'Provider unlinked successfully' })
+      } else {
+        setFeedback({ type: 'error', message: result.error })
+      }
+      closeUnlinkModal()
+      setProviderToUnlink(null)
+      router.refresh()
+    })
+  }
+
+  const handleLinkOAuth = (provider: string) => {
+    window.location.href = `/api/auth/link/${provider}`
+  }
+
+  const handleSetPassword = () => {
+    startTransition(async () => {
+      const result = await setPassword({
+        password: passwordForm.password,
+        confirmPassword: passwordForm.confirmNewPassword,
+      })
+      if (result.success) {
+        setFeedback({ type: 'success', message: 'Password set successfully' })
+        setPasswordForm((prev) => ({
+          ...prev,
+          password: '',
+          confirmNewPassword: '',
+        }))
+        router.refresh()
+      } else {
+        setFeedback({ type: 'error', message: result.error })
+      }
+    })
+  }
+
+  const handleChangePassword = () => {
+    startTransition(async () => {
+      const result = await changePassword({
+        currentPassword: passwordForm.currentPassword,
+        newPassword: passwordForm.newPassword,
+        confirmPassword: passwordForm.confirmPassword,
+      })
+      if (result.success) {
+        setFeedback({ type: 'success', message: 'Password changed successfully' })
+        setPasswordForm({
+          currentPassword: '',
+          newPassword: '',
+          confirmPassword: '',
+          password: '',
+          confirmNewPassword: '',
+        })
+      } else {
+        setFeedback({ type: 'error', message: result.error })
+      }
+    })
+  }
+
+  return (
+    <Container py="xl" size="sm">
+      <Stack gap="xl">
+        {feedback && (
+          <Paper
+            bg={feedback.type === 'success' ? 'teal.0' : 'red.0'}
+            p="sm"
+            radius="sm"
+          >
+            <Text
+              c={feedback.type === 'success' ? 'teal.8' : 'red.8'}
+              size="sm"
+            >
+              {feedback.message}
+            </Text>
+          </Paper>
+        )}
+
+        {/* Linked Login Methods */}
+        <Paper p="lg" radius="md" shadow="sm" withBorder>
+          <Stack gap="md">
+            <Title order={4}>Linked Login Methods</Title>
+
+            {Object.entries(PROVIDER_CONFIG).map(
+              ([provider, { label, icon: Icon, color }]) => {
+                const linked = isProviderLinked(provider)
+                return (
+                  <Group justify="space-between" key={provider}>
+                    <Group>
+                      <Icon size={24} stroke={1.5} />
+                      <Text>{label}</Text>
+                      <Badge
+                        color={linked ? 'green' : 'gray'}
+                        size="sm"
+                        variant="light"
+                      >
+                        {linked ? 'Linked' : 'Not linked'}
+                      </Badge>
+                    </Group>
+                    {linked ? (
+                      <Button
+                        color="red"
+                        disabled={isPending}
+                        leftSection={<IconLinkOff size={16} />}
+                        onClick={() => handleUnlinkClick(provider)}
+                        size="compact-sm"
+                        variant="light"
+                      >
+                        Unlink
+                      </Button>
+                    ) : (
+                      <Button
+                        color={color}
+                        disabled={isPending}
+                        leftSection={<IconLink size={16} />}
+                        onClick={() => handleLinkOAuth(provider)}
+                        size="compact-sm"
+                        variant="light"
+                      >
+                        Link
+                      </Button>
+                    )}
+                  </Group>
+                )
+              },
+            )}
+
+            {/* Email/Password row */}
+            <Group justify="space-between">
+              <Group>
+                <IconMail size={24} stroke={1.5} />
+                <Text>Email / Password</Text>
+                <Badge
+                  color={linkedAccounts.hasPassword ? 'green' : 'gray'}
+                  size="sm"
+                  variant="light"
+                >
+                  {linkedAccounts.hasPassword ? 'Set' : 'Not set'}
+                </Badge>
+              </Group>
+            </Group>
+          </Stack>
+        </Paper>
+
+        {/* Password Management */}
+        <Paper p="lg" radius="md" shadow="sm" withBorder>
+          <Stack gap="md">
+            <Group>
+              <IconLock size={20} stroke={1.5} />
+              <Title order={4}>
+                {linkedAccounts.hasPassword
+                  ? 'Change Password'
+                  : 'Set Password'}
+              </Title>
+            </Group>
+
+            {linkedAccounts.hasPassword ? (
+              <>
+                <PasswordInput
+                  disabled={isPending}
+                  label="Current Password"
+                  onChange={(e) =>
+                    setPasswordForm((prev) => ({
+                      ...prev,
+                      currentPassword: e.currentTarget.value,
+                    }))
+                  }
+                  value={passwordForm.currentPassword}
+                />
+                <PasswordInput
+                  disabled={isPending}
+                  label="New Password"
+                  onChange={(e) =>
+                    setPasswordForm((prev) => ({
+                      ...prev,
+                      newPassword: e.currentTarget.value,
+                    }))
+                  }
+                  value={passwordForm.newPassword}
+                />
+                <PasswordInput
+                  disabled={isPending}
+                  label="Confirm New Password"
+                  onChange={(e) =>
+                    setPasswordForm((prev) => ({
+                      ...prev,
+                      confirmPassword: e.currentTarget.value,
+                    }))
+                  }
+                  value={passwordForm.confirmPassword}
+                />
+                <Button
+                  disabled={
+                    isPending ||
+                    !passwordForm.currentPassword ||
+                    !passwordForm.newPassword ||
+                    !passwordForm.confirmPassword
+                  }
+                  onClick={handleChangePassword}
+                >
+                  Change Password
+                </Button>
+              </>
+            ) : (
+              <>
+                <PasswordInput
+                  disabled={isPending}
+                  label="Password"
+                  onChange={(e) =>
+                    setPasswordForm((prev) => ({
+                      ...prev,
+                      password: e.currentTarget.value,
+                    }))
+                  }
+                  value={passwordForm.password}
+                />
+                <PasswordInput
+                  disabled={isPending}
+                  label="Confirm Password"
+                  onChange={(e) =>
+                    setPasswordForm((prev) => ({
+                      ...prev,
+                      confirmNewPassword: e.currentTarget.value,
+                    }))
+                  }
+                  value={passwordForm.confirmNewPassword}
+                />
+                <Button
+                  disabled={
+                    isPending ||
+                    !passwordForm.password ||
+                    !passwordForm.confirmNewPassword
+                  }
+                  onClick={handleSetPassword}
+                >
+                  Set Password
+                </Button>
+              </>
+            )}
+          </Stack>
+        </Paper>
+      </Stack>
+
+      {/* Unlink Confirmation Modal */}
+      <Modal
+        centered
+        onClose={closeUnlinkModal}
+        opened={unlinkModalOpened}
+        title="Unlink Provider"
+      >
+        <Stack>
+          <Text>
+            Are you sure you want to unlink{' '}
+            {providerToUnlink &&
+              PROVIDER_CONFIG[
+                providerToUnlink as keyof typeof PROVIDER_CONFIG
+              ]?.label}
+            ? You will no longer be able to sign in with this provider.
+          </Text>
+          <Group justify="flex-end">
+            <Button onClick={closeUnlinkModal} variant="default">
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              loading={isPending}
+              onClick={handleUnlinkConfirm}
+            >
+              Unlink
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </Container>
+  )
+}

--- a/src/app/(main)/account/actions.ts
+++ b/src/app/(main)/account/actions.ts
@@ -1,0 +1,191 @@
+'use server'
+
+import { and, eq } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+
+import { auth, hashPassword, verifyPassword } from '~/server/auth'
+import { db } from '~/server/db'
+import { accounts, users } from '~/server/db/schema'
+
+type ActionResult = { success: true } | { success: false; error: string }
+
+async function getAuthenticatedUserId(): Promise<string> {
+  const session = await auth()
+  if (!session?.user?.id) {
+    throw new Error('Unauthorized')
+  }
+  return session.user.id
+}
+
+/**
+ * Unlink an OAuth provider from the current user's account.
+ * Prevents unlinking if it would leave the user with no login methods.
+ */
+export async function unlinkProvider(provider: string): Promise<ActionResult> {
+  try {
+    const userId = await getAuthenticatedUserId()
+
+    // Get current linked accounts and password status
+    const [linkedAccounts, user] = await Promise.all([
+      db
+        .select({ provider: accounts.provider })
+        .from(accounts)
+        .where(eq(accounts.userId, userId)),
+      db.query.users.findFirst({
+        where: eq(users.id, userId),
+        columns: { passwordHash: true },
+      }),
+    ])
+
+    const hasPassword = !!user?.passwordHash
+    const oauthCount = linkedAccounts.length
+    const totalMethods = oauthCount + (hasPassword ? 1 : 0)
+
+    // Check if this is the target provider
+    const hasProvider = linkedAccounts.some((a) => a.provider === provider)
+    if (!hasProvider) {
+      return { success: false, error: 'Provider is not linked to your account' }
+    }
+
+    // Prevent removing the last login method
+    if (totalMethods <= 1) {
+      return {
+        success: false,
+        error: 'At least one login method is required',
+      }
+    }
+
+    // Delete the provider link
+    await db
+      .delete(accounts)
+      .where(
+        and(eq(accounts.userId, userId), eq(accounts.provider, provider)),
+      )
+
+    revalidatePath('/account')
+    return { success: true }
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return { success: false, error: 'Unauthorized' }
+    }
+    return { success: false, error: 'Failed to unlink provider' }
+  }
+}
+
+const setPasswordSchema = z.object({
+  password: z.string().min(8, 'Password must be at least 8 characters'),
+  confirmPassword: z.string(),
+}).refine((data) => data.password === data.confirmPassword, {
+  message: 'Passwords do not match',
+  path: ['confirmPassword'],
+})
+
+/**
+ * Set a password for the current user (for users who only have OAuth).
+ */
+export async function setPassword(data: {
+  password: string
+  confirmPassword: string
+}): Promise<ActionResult> {
+  try {
+    const userId = await getAuthenticatedUserId()
+
+    const parsed = setPasswordSchema.safeParse(data)
+    if (!parsed.success) {
+      return {
+        success: false,
+        error: parsed.error.errors[0]?.message ?? 'Invalid input',
+      }
+    }
+
+    // Check if password is already set
+    const user = await db.query.users.findFirst({
+      where: eq(users.id, userId),
+      columns: { passwordHash: true },
+    })
+
+    if (user?.passwordHash) {
+      return {
+        success: false,
+        error: 'Password is already set. Use change password instead.',
+      }
+    }
+
+    const hash = await hashPassword(parsed.data.password)
+
+    await db.update(users).set({ passwordHash: hash }).where(eq(users.id, userId))
+
+    revalidatePath('/account')
+    return { success: true }
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return { success: false, error: 'Unauthorized' }
+    }
+    return { success: false, error: 'Failed to set password' }
+  }
+}
+
+const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1, 'Current password is required'),
+  newPassword: z.string().min(8, 'New password must be at least 8 characters'),
+  confirmPassword: z.string(),
+}).refine((data) => data.newPassword === data.confirmPassword, {
+  message: 'Passwords do not match',
+  path: ['confirmPassword'],
+})
+
+/**
+ * Change the current user's password.
+ * Requires the current password for verification.
+ */
+export async function changePassword(data: {
+  currentPassword: string
+  newPassword: string
+  confirmPassword: string
+}): Promise<ActionResult> {
+  try {
+    const userId = await getAuthenticatedUserId()
+
+    const parsed = changePasswordSchema.safeParse(data)
+    if (!parsed.success) {
+      return {
+        success: false,
+        error: parsed.error.errors[0]?.message ?? 'Invalid input',
+      }
+    }
+
+    const user = await db.query.users.findFirst({
+      where: eq(users.id, userId),
+      columns: { passwordHash: true },
+    })
+
+    if (!user?.passwordHash) {
+      return {
+        success: false,
+        error: 'No password set. Use set password instead.',
+      }
+    }
+
+    const isValid = await verifyPassword(
+      parsed.data.currentPassword,
+      user.passwordHash,
+    )
+
+    if (!isValid) {
+      return { success: false, error: 'Current password is incorrect' }
+    }
+
+    const hash = await hashPassword(parsed.data.newPassword)
+
+    await db.update(users).set({ passwordHash: hash }).where(eq(users.id, userId))
+
+    revalidatePath('/account')
+    return { success: true }
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Unauthorized') {
+      return { success: false, error: 'Unauthorized' }
+    }
+    return { success: false, error: 'Failed to change password' }
+  }
+}

--- a/src/app/(main)/account/page.tsx
+++ b/src/app/(main)/account/page.tsx
@@ -1,0 +1,19 @@
+import { api, HydrateClient } from '~/trpc/server'
+
+import { AccountContent } from './AccountContent'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * Account settings page (Server Component).
+ * Fetches linked accounts data and passes to client component.
+ */
+export default async function AccountPage() {
+  const linkedAccounts = await api.account.getLinkedAccounts()
+
+  return (
+    <HydrateClient>
+      <AccountContent linkedAccounts={linkedAccounts} />
+    </HydrateClient>
+  )
+}

--- a/src/app/api/auth/link/[provider]/route.ts
+++ b/src/app/api/auth/link/[provider]/route.ts
@@ -1,0 +1,26 @@
+import { auth, signIn } from '~/server/auth'
+
+const ALLOWED_PROVIDERS = ['google', 'discord'] as const
+
+/**
+ * GET /api/auth/link/[provider]
+ * Initiates OAuth flow to link a new provider to the authenticated user's account.
+ * NextAuth's allowDangerousEmailAccountLinking handles the actual account linking.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ provider: string }> },
+) {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  const { provider } = await params
+
+  if (!ALLOWED_PROVIDERS.includes(provider as (typeof ALLOWED_PROVIDERS)[number])) {
+    return new Response('Invalid provider', { status: 400 })
+  }
+
+  await signIn(provider, { redirectTo: '/account?linked=success' })
+}

--- a/src/components/layouts/AppShell.tsx
+++ b/src/components/layouts/AppShell.tsx
@@ -22,6 +22,7 @@ import {
   IconLogout,
   IconPlayerPause,
   IconPlayerPlay,
+  IconUser,
   IconUsers,
 } from '@tabler/icons-react'
 import Link from 'next/link'
@@ -47,6 +48,7 @@ const navItems = [
   { href: '/stores', label: 'Stores', icon: IconBuildingStore },
   { href: '/players', label: 'Players', icon: IconUsers },
   { href: '/statistics', label: 'Statistics', icon: IconChartBar },
+  { href: '/account', label: 'Account', icon: IconUser },
   { href: '/help', label: 'Help', icon: IconHelp },
 ]
 

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,3 +1,4 @@
+import { accountRouter } from '~/server/api/routers/account'
 import { allInRouter } from '~/server/api/routers/allIn'
 import { authRouter } from '~/server/api/routers/auth'
 import { cashGameRouter } from '~/server/api/routers/cashGame'
@@ -21,6 +22,7 @@ import {
  * All routers added in /api/routers should be manually added here.
  */
 export const appRouter = createTRPCRouter({
+  account: accountRouter,
   allIn: allInRouter,
   auth: authRouter,
   cashGame: cashGameRouter,

--- a/src/server/api/routers/account.ts
+++ b/src/server/api/routers/account.ts
@@ -1,0 +1,39 @@
+import { eq } from 'drizzle-orm'
+
+import { accounts, users } from '~/server/db/schema'
+import { createTRPCRouter, protectedProcedure } from '../trpc'
+
+/**
+ * Account router for managing linked login methods.
+ * Provides queries for retrieving linked OAuth providers and password status.
+ */
+export const accountRouter = createTRPCRouter({
+  /**
+   * Get all linked accounts and password status for the current user.
+   */
+  getLinkedAccounts: protectedProcedure.query(async ({ ctx }) => {
+    const userId = ctx.session.user.id
+
+    const [linkedAccounts, user] = await Promise.all([
+      ctx.db
+        .select({
+          provider: accounts.provider,
+          providerAccountId: accounts.providerAccountId,
+        })
+        .from(accounts)
+        .where(eq(accounts.userId, userId)),
+      ctx.db.query.users.findFirst({
+        where: eq(users.id, userId),
+        columns: { passwordHash: true },
+      }),
+    ])
+
+    return {
+      providers: linkedAccounts.map((a) => ({
+        provider: a.provider,
+        providerAccountId: a.providerAccountId,
+      })),
+      hasPassword: !!user?.passwordHash,
+    }
+  }),
+})

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -113,7 +113,13 @@ export const authConfig = {
      * Only configured if environment variables are set.
      */
     ...(process.env.AUTH_DISCORD_ID && process.env.AUTH_DISCORD_SECRET
-      ? [DiscordProvider]
+      ? [
+          DiscordProvider({
+            clientId: process.env.AUTH_DISCORD_ID,
+            clientSecret: process.env.AUTH_DISCORD_SECRET,
+            allowDangerousEmailAccountLinking: true,
+          }),
+        ]
       : []),
   ],
   adapter: DrizzleAdapter(db, {


### PR DESCRIPTION
## Summary
- Add account settings page where users can view and manage linked login methods (Google, Discord, Email/Password)
- Implement OAuth provider linking/unlinking with safety checks (prevents removing the last login method)
- Add password set/change functionality for OAuth-only users
- Enable Discord OAuth auto-linking via `allowDangerousEmailAccountLinking`
- Add Account navigation item to the AppShell sidebar

## Changes
1. **tRPC Account Router** (`src/server/api/routers/account.ts`): `getLinkedAccounts` query returning linked providers and password status
2. **Server Actions** (`src/app/(main)/account/actions.ts`): `unlinkProvider`, `setPassword`, `changePassword`
3. **OAuth Link API Route** (`src/app/api/auth/link/[provider]/route.ts`): GET handler initiating OAuth flow for account linking
4. **NextAuth Config** (`src/server/auth/config.ts`): Discord `allowDangerousEmailAccountLinking: true`
5. **Account Page** (`src/app/(main)/account/`): Server Component + Client Component with linked methods display, link/unlink buttons, password management forms
6. **AppShell** (`src/components/layouts/AppShell.tsx`): Added Account nav item

## Test plan
- [ ] Navigate to Account page from sidebar
- [ ] Verify linked providers are displayed correctly
- [ ] Test OAuth provider linking (Google, Discord)
- [ ] Test OAuth provider unlinking with confirmation modal
- [ ] Verify last login method cannot be unlinked
- [ ] Test password setting for OAuth-only users
- [ ] Test password change with current password verification
- [ ] Verify error messages are displayed in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)