### PR TITLE
fix(ui): use placeholder for tablemate name instead of default Seat X

### DIFF
--- a/src/app/(main)/sessions/active/PlayerEditModal.tsx
+++ b/src/app/(main)/sessions/active/PlayerEditModal.tsx
@@ -51,6 +51,7 @@ interface PlayerEditModalProps {
   player: PlayerData | null
   tablemateId: string
   sessionId: string
+  seatNumber: number | null
 }
 
 /**
@@ -64,6 +65,7 @@ export function PlayerEditModal({
   player,
   tablemateId,
   sessionId,
+  seatNumber,
 }: PlayerEditModalProps) {
   const utils = api.useUtils()
 
@@ -281,9 +283,10 @@ export function PlayerEditModal({
         })
       } else {
         // Just update the temporary player (no persist)
+        // Skip name update if nameSearch is empty (keep current empty name)
         await updatePlayerMutation.mutateAsync({
           id: player.id,
-          name: nameSearch.trim(),
+          name: nameSearch.trim() || undefined,
           generalNotes: values.generalNotes || undefined,
         })
 
@@ -410,7 +413,7 @@ export function PlayerEditModal({
       onClose={onClose}
       opened={opened}
       size="lg"
-      title={`${player?.name ?? ''} を編集`}
+      title={`${player?.name || (seatNumber ? `Seat ${seatNumber}` : '')} を編集`}
     >
       <form onSubmit={handleSubmit}>
         <ScrollArea.Autosize mah="70vh">
@@ -447,7 +450,7 @@ export function PlayerEditModal({
                       }}
                       onClick={() => nameCombobox.openDropdown()}
                       onFocus={() => nameCombobox.openDropdown()}
-                      placeholder="プレイヤー名を入力..."
+                      placeholder={seatNumber ? `Seat ${seatNumber}` : 'プレイヤー名を入力...'}
                       rightSection={<Combobox.Chevron />}
                       value={
                         selectedExistingPlayerId

--- a/src/app/(main)/sessions/active/PlayerEditModal.tsx
+++ b/src/app/(main)/sessions/active/PlayerEditModal.tsx
@@ -125,7 +125,9 @@ export function PlayerEditModal({
   useEffect(() => {
     if (opened && player) {
       form.setValues({
-        name: player.name,
+        // For temporary players, name field is not used (nameSearch is used instead),
+        // so use a placeholder value to pass validation
+        name: player.isTemporary ? (player.name || 'temp') : player.name,
         generalNotes: player.generalNotes ?? '',
       })
       const tagIds = player.tags.map((t) => t.id)

--- a/src/app/(main)/sessions/active/TablematesCard.tsx
+++ b/src/app/(main)/sessions/active/TablematesCard.tsx
@@ -513,6 +513,7 @@ export function TablematesCard({ sessionId }: TablematesCardProps) {
               }
             : null
         }
+        seatNumber={selectedTablemate?.seatNumber ?? null}
         sessionId={sessionId}
         tablemateId={selectedTablemate?.id ?? ''}
       />

--- a/src/app/(main)/sessions/active/TablematesCard.tsx
+++ b/src/app/(main)/sessions/active/TablematesCard.tsx
@@ -336,8 +336,13 @@ export function TablematesCard({ sessionId }: TablematesCardProps) {
                         >
                           {seatNumber}
                         </Badge>
-                        <Text fw={500} size="sm" style={{ flexShrink: 0 }}>
-                          {tablemate.player?.name}
+                        <Text
+                          c={tablemate.player?.name ? undefined : 'dimmed'}
+                          fw={500}
+                          size="sm"
+                          style={{ flexShrink: 0 }}
+                        >
+                          {tablemate.player?.name || `Seat ${seatNumber}`}
                         </Text>
                         {/* Player tags */}
                         {playerTags.slice(0, 3).map((ta) => (

--- a/src/server/api/routers/player.ts
+++ b/src/server/api/routers/player.ts
@@ -237,6 +237,11 @@ export const playerRouter = createTRPCRouter({
       if (input.generalNotes !== undefined)
         updateData.generalNotes = input.generalNotes
 
+      // If no fields to update, return existing record
+      if (Object.keys(updateData).length === 0) {
+        return existing
+      }
+
       const [updated] = await ctx.db
         .update(players)
         .set(updateData)

--- a/src/server/api/routers/sessionTablemate.ts
+++ b/src/server/api/routers/sessionTablemate.ts
@@ -122,8 +122,8 @@ export const sessionTablemateRouter = createTRPCRouter({
         })
       }
 
-      // Create temporary player
-      const playerName = `Seat ${input.seatNumber}`
+      // Create temporary player with empty name (UI shows "Seat X" as placeholder)
+      const playerName = ''
       const [player] = await ctx.db
         .insert(players)
         .values({


### PR DESCRIPTION
## Summary
- 同卓者追加時のプレイヤー名デフォルト値を `Seat X` から空文字列に変更
- UIでは `Seat X` をplaceholderとして表示し、空欄のまま保存した場合は名前を変更しない
- 同卓者リストでも名前が空の場合は `Seat X` をフォールバック表示（dimmed color）

## Changes
- `src/server/api/routers/sessionTablemate.ts`: create プロシージャのデフォルト名を空文字列に変更
- `src/app/(main)/sessions/active/PlayerEditModal.tsx`: seatNumber prop 追加、placeholder 設定、空名保存時のスキップ処理
- `src/app/(main)/sessions/active/TablematesCard.tsx`: 表示名フォールバック追加、seatNumber を PlayerEditModal に受け渡し

## Test plan
- [ ] 空席をタップして同卓者を追加し、プレイヤー名が空で作成されることを確認
- [ ] 編集モーダルで placeholder に `Seat X` が表示されることを確認
- [ ] 名前を空欄のまま保存して名前が変更されないことを確認
- [ ] 同卓者リストで空名のプレイヤーに `Seat X` がフォールバック表示されることを確認
- [ ] 名前を入力して保存し、正常に反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)