### PR TITLE
fix(account): add Suspense boundary and show email on account page

### DIFF
--- a/src/app/(main)/account/AccountContent.tsx
+++ b/src/app/(main)/account/AccountContent.tsx
@@ -37,6 +37,7 @@ interface AccountContentProps {
   linkedAccounts: {
     providers: LinkedProvider[]
     hasPassword: boolean
+    email: string
   }
 }
 
@@ -121,7 +122,10 @@ export function AccountContent({ linkedAccounts }: AccountContentProps) {
         confirmPassword: passwordForm.confirmNewPassword,
       })
       if (result.success) {
-        setFeedback({ type: 'success', message: 'Password set successfully' })
+        setFeedback({
+          type: 'success',
+          message: `Password set successfully. You can now sign in with ${linkedAccounts.email} and your password.`,
+        })
         setPasswordForm((prev) => ({
           ...prev,
           password: '',
@@ -251,6 +255,10 @@ export function AccountContent({ linkedAccounts }: AccountContentProps) {
                   : 'Set Password'}
               </Title>
             </Group>
+
+            <Text c="dimmed" size="sm">
+              Login email: {linkedAccounts.email}
+            </Text>
 
             {linkedAccounts.hasPassword ? (
               <>

--- a/src/app/(main)/account/page.tsx
+++ b/src/app/(main)/account/page.tsx
@@ -1,3 +1,7 @@
+import { Suspense } from 'react'
+
+import { Container, Text } from '@mantine/core'
+
 import { api, HydrateClient } from '~/trpc/server'
 
 import { AccountContent } from './AccountContent'
@@ -7,13 +11,22 @@ export const dynamic = 'force-dynamic'
 /**
  * Account settings page (Server Component).
  * Fetches linked accounts data and passes to client component.
+ * Wrapped in Suspense to support useSearchParams() in AccountContent.
  */
 export default async function AccountPage() {
   const linkedAccounts = await api.account.getLinkedAccounts()
 
   return (
     <HydrateClient>
-      <AccountContent linkedAccounts={linkedAccounts} />
+      <Suspense
+        fallback={
+          <Container py="xl" size="sm">
+            <Text ta="center">Loading...</Text>
+          </Container>
+        }
+      >
+        <AccountContent linkedAccounts={linkedAccounts} />
+      </Suspense>
     </HydrateClient>
   )
 }

--- a/src/server/api/routers/account.ts
+++ b/src/server/api/routers/account.ts
@@ -24,7 +24,7 @@ export const accountRouter = createTRPCRouter({
         .where(eq(accounts.userId, userId)),
       ctx.db.query.users.findFirst({
         where: eq(users.id, userId),
-        columns: { passwordHash: true },
+        columns: { passwordHash: true, email: true },
       }),
     ])
 
@@ -34,6 +34,7 @@ export const accountRouter = createTRPCRouter({
         providerAccountId: a.providerAccountId,
       })),
       hasPassword: !!user?.passwordHash,
+      email: user?.email ?? '',
     }
   }),
 })


### PR DESCRIPTION
Fixes client-side crash when typing in password fields on /account page caused by useSearchParams() being used without a Suspense boundary. Also adds email display in password section so users know which email to use for credentials login.