### PR TITLE
fix(auth): Vercelプレビュー環境で自動ログイン

### DIFF
--- a/src/app/api/auth/auto-login/route.ts
+++ b/src/app/api/auth/auto-login/route.ts
@@ -20,12 +20,13 @@ export async function GET() {
   const email = process.env.PREVIEW_AUTO_LOGIN_EMAIL
   const password = process.env.PREVIEW_AUTO_LOGIN_PASSWORD
 
-  if (!email || !password) {
-    const baseUrl = `https://${process.env.VERCEL_URL}`
-    return NextResponse.redirect(new URL('/auth/signin', baseUrl))
-  }
-
   const baseUrl = `https://${process.env.VERCEL_URL}`
+
+  if (!email || !password) {
+    return NextResponse.redirect(
+      new URL('/auth/signin?auto-login-failed=1', baseUrl),
+    )
+  }
 
   try {
     // NextAuth v5 server-side signIn throws NEXT_REDIRECT on success
@@ -48,7 +49,10 @@ export async function GET() {
       throw error
     }
 
-    // Authentication failed (e.g. account doesn't exist) — fall back to manual sign-in
-    return NextResponse.redirect(new URL('/auth/signin', baseUrl))
+    // Authentication failed (e.g. account doesn't exist) — fall back to manual sign-in.
+    // Use query param to prevent infinite redirect loop with the signin page.
+    return NextResponse.redirect(
+      new URL('/auth/signin?auto-login-failed=1', baseUrl),
+    )
   }
 }

--- a/src/app/api/auth/auto-login/route.ts
+++ b/src/app/api/auth/auto-login/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server'
+
+import { signIn } from '~/server/auth'
+
+/**
+ * Auto-login API route for Vercel preview deployments.
+ *
+ * Automatically signs in with credentials from environment variables
+ * so PR reviewers don't need to manually enter login details.
+ * Only works when VERCEL_ENV is "preview".
+ */
+export async function GET() {
+  if (process.env.VERCEL_ENV !== 'preview') {
+    return NextResponse.json(
+      { error: 'Auto-login is only available in preview environments' },
+      { status: 403 },
+    )
+  }
+
+  const email = process.env.PREVIEW_AUTO_LOGIN_EMAIL
+  const password = process.env.PREVIEW_AUTO_LOGIN_PASSWORD
+
+  if (!email || !password) {
+    const baseUrl = `https://${process.env.VERCEL_URL}`
+    return NextResponse.redirect(new URL('/auth/signin', baseUrl))
+  }
+
+  // NextAuth v5 server-side signIn handles redirect internally
+  await signIn('credentials', {
+    email,
+    password,
+    redirectTo: '/dashboard',
+  })
+}

--- a/src/app/api/auth/auto-login/route.ts
+++ b/src/app/api/auth/auto-login/route.ts
@@ -25,10 +25,30 @@ export async function GET() {
     return NextResponse.redirect(new URL('/auth/signin', baseUrl))
   }
 
-  // NextAuth v5 server-side signIn handles redirect internally
-  await signIn('credentials', {
-    email,
-    password,
-    redirectTo: '/dashboard',
-  })
+  const baseUrl = `https://${process.env.VERCEL_URL}`
+
+  try {
+    // NextAuth v5 server-side signIn throws NEXT_REDIRECT on success
+    await signIn('credentials', {
+      email,
+      password,
+      redirectTo: '/dashboard',
+    })
+  } catch (error) {
+    // NextAuth v5 uses thrown redirects for successful sign-in.
+    // Re-throw redirect errors so Next.js handles the redirect.
+    if (
+      error instanceof Error &&
+      'digest' in error &&
+      typeof (error as Record<string, unknown>).digest === 'string' &&
+      ((error as Record<string, unknown>).digest as string).startsWith(
+        'NEXT_REDIRECT',
+      )
+    ) {
+      throw error
+    }
+
+    // Authentication failed (e.g. account doesn't exist) — fall back to manual sign-in
+    return NextResponse.redirect(new URL('/auth/signin', baseUrl))
+  }
 }

--- a/src/app/auth/signin/SignInContent.tsx
+++ b/src/app/auth/signin/SignInContent.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import {
+  Alert,
+  Anchor,
+  Button,
+  Container,
+  Divider,
+  Paper,
+  PasswordInput,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+} from '@mantine/core'
+import { useForm } from '@mantine/form'
+import {
+  IconAlertCircle,
+  IconBrandDiscord,
+  IconBrandGoogle,
+} from '@tabler/icons-react'
+import { zodResolver } from 'mantine-form-zod-resolver'
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { signIn } from 'next-auth/react'
+import { Suspense, useState } from 'react'
+import { z } from 'zod'
+
+const signInSchema = z.object({
+  email: z
+    .string()
+    .email({ message: '有効なメールアドレスを入力してください' }),
+  password: z.string().min(1, { message: 'パスワードを入力してください' }),
+})
+
+function SignInForm() {
+  const searchParams = useSearchParams()
+  const callbackUrl = searchParams.get('callbackUrl') ?? '/'
+  const error = searchParams.get('error')
+  const [isLoading, setIsLoading] = useState(false)
+  const [credentialsError, setCredentialsError] = useState<string | null>(null)
+
+  const form = useForm({
+    mode: 'uncontrolled',
+    initialValues: {
+      email: '',
+      password: '',
+    },
+    validate: zodResolver(signInSchema),
+  })
+
+  const handleCredentialsSubmit = form.onSubmit(async (values) => {
+    setIsLoading(true)
+    setCredentialsError(null)
+
+    const result = await signIn('credentials', {
+      email: values.email,
+      password: values.password,
+      callbackUrl,
+      redirect: false,
+    })
+
+    setIsLoading(false)
+
+    if (result?.error) {
+      setCredentialsError('メールアドレスまたはパスワードが正しくありません')
+    } else if (result?.ok) {
+      window.location.href = callbackUrl
+    }
+  })
+
+  const handleOAuthSignIn = (provider: string) => {
+    setIsLoading(true)
+    signIn(provider, { callbackUrl })
+  }
+
+  const getErrorMessage = (errorCode: string | null) => {
+    switch (errorCode) {
+      case 'OAuthAccountNotLinked':
+        return 'このメールアドレスは別の方法で登録されています'
+      case 'CredentialsSignin':
+        return 'メールアドレスまたはパスワードが正しくありません'
+      case 'AccessDenied':
+        return 'アクセスが拒否されました'
+      default:
+        return errorCode ? 'ログインに失敗しました' : null
+    }
+  }
+
+  const errorMessage = getErrorMessage(error) ?? credentialsError
+
+  return (
+    <Container py="xl" size="xs">
+      <Stack align="center" gap="lg">
+        <Title order={1}>ログイン</Title>
+        <Text c="dimmed" ta="center">
+          ポーカーセッショントラッカーにログイン
+        </Text>
+      </Stack>
+
+      <Paper mt="xl" p="xl" radius="md" shadow="md" withBorder>
+        {errorMessage && (
+          <Alert
+            color="red"
+            icon={<IconAlertCircle size={16} />}
+            mb="md"
+            title="エラー"
+          >
+            {errorMessage}
+          </Alert>
+        )}
+
+        <form onSubmit={handleCredentialsSubmit}>
+          <Stack>
+            <TextInput
+              label="メールアドレス"
+              placeholder="you@example.com"
+              withAsterisk
+              {...form.getInputProps('email')}
+            />
+            <PasswordInput
+              label="パスワード"
+              placeholder="パスワードを入力"
+              withAsterisk
+              {...form.getInputProps('password')}
+            />
+            <Button fullWidth loading={isLoading} mt="md" type="submit">
+              ログイン
+            </Button>
+          </Stack>
+        </form>
+
+        <Divider label="または" labelPosition="center" my="lg" />
+
+        <Stack>
+          <Button
+            leftSection={<IconBrandGoogle size={18} />}
+            onClick={() => handleOAuthSignIn('google')}
+            variant="default"
+          >
+            Googleでログイン
+          </Button>
+          <Button
+            leftSection={<IconBrandDiscord size={18} />}
+            onClick={() => handleOAuthSignIn('discord')}
+            variant="default"
+          >
+            Discordでログイン
+          </Button>
+        </Stack>
+
+        <Text c="dimmed" mt="md" size="sm" ta="center">
+          アカウントをお持ちでないですか？{' '}
+          <Anchor component={Link} href="/auth/register" size="sm">
+            新規登録
+          </Anchor>
+        </Text>
+      </Paper>
+
+      <Button component={Link} href="/" mt="lg" variant="subtle" w="100%">
+        ホームに戻る
+      </Button>
+    </Container>
+  )
+}
+
+export default function SignInContent() {
+  return (
+    <Suspense
+      fallback={
+        <Container py="xl" size="xs">
+          <Text ta="center">読み込み中...</Text>
+        </Container>
+      }
+    >
+      <SignInForm />
+    </Suspense>
+  )
+}

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,179 +1,24 @@
-'use client'
+import { redirect } from 'next/navigation'
 
-import {
-  Alert,
-  Anchor,
-  Button,
-  Container,
-  Divider,
-  Paper,
-  PasswordInput,
-  Stack,
-  Text,
-  TextInput,
-  Title,
-} from '@mantine/core'
-import { useForm } from '@mantine/form'
-import {
-  IconAlertCircle,
-  IconBrandDiscord,
-  IconBrandGoogle,
-} from '@tabler/icons-react'
-import { zodResolver } from 'mantine-form-zod-resolver'
-import Link from 'next/link'
-import { useSearchParams } from 'next/navigation'
-import { signIn } from 'next-auth/react'
-import { Suspense, useState } from 'react'
-import { z } from 'zod'
+import SignInContent from './SignInContent'
 
-const signInSchema = z.object({
-  email: z
-    .string()
-    .email({ message: '有効なメールアドレスを入力してください' }),
-  password: z.string().min(1, { message: 'パスワードを入力してください' }),
-})
-
-function SignInContent() {
-  const searchParams = useSearchParams()
-  const callbackUrl = searchParams.get('callbackUrl') ?? '/'
-  const error = searchParams.get('error')
-  const [isLoading, setIsLoading] = useState(false)
-  const [credentialsError, setCredentialsError] = useState<string | null>(null)
-
-  const form = useForm({
-    mode: 'uncontrolled',
-    initialValues: {
-      email: '',
-      password: '',
-    },
-    validate: zodResolver(signInSchema),
-  })
-
-  const handleCredentialsSubmit = form.onSubmit(async (values) => {
-    setIsLoading(true)
-    setCredentialsError(null)
-
-    const result = await signIn('credentials', {
-      email: values.email,
-      password: values.password,
-      callbackUrl,
-      redirect: false,
-    })
-
-    setIsLoading(false)
-
-    if (result?.error) {
-      setCredentialsError('メールアドレスまたはパスワードが正しくありません')
-    } else if (result?.ok) {
-      window.location.href = callbackUrl
-    }
-  })
-
-  const handleOAuthSignIn = (provider: string) => {
-    setIsLoading(true)
-    signIn(provider, { callbackUrl })
-  }
-
-  const getErrorMessage = (errorCode: string | null) => {
-    switch (errorCode) {
-      case 'OAuthAccountNotLinked':
-        return 'このメールアドレスは別の方法で登録されています'
-      case 'CredentialsSignin':
-        return 'メールアドレスまたはパスワードが正しくありません'
-      case 'AccessDenied':
-        return 'アクセスが拒否されました'
-      default:
-        return errorCode ? 'ログインに失敗しました' : null
-    }
-  }
-
-  const errorMessage = getErrorMessage(error) ?? credentialsError
-
-  return (
-    <Container py="xl" size="xs">
-      <Stack align="center" gap="lg">
-        <Title order={1}>ログイン</Title>
-        <Text c="dimmed" ta="center">
-          ポーカーセッショントラッカーにログイン
-        </Text>
-      </Stack>
-
-      <Paper mt="xl" p="xl" radius="md" shadow="md" withBorder>
-        {errorMessage && (
-          <Alert
-            color="red"
-            icon={<IconAlertCircle size={16} />}
-            mb="md"
-            title="エラー"
-          >
-            {errorMessage}
-          </Alert>
-        )}
-
-        <form onSubmit={handleCredentialsSubmit}>
-          <Stack>
-            <TextInput
-              label="メールアドレス"
-              placeholder="you@example.com"
-              withAsterisk
-              {...form.getInputProps('email')}
-            />
-            <PasswordInput
-              label="パスワード"
-              placeholder="パスワードを入力"
-              withAsterisk
-              {...form.getInputProps('password')}
-            />
-            <Button fullWidth loading={isLoading} mt="md" type="submit">
-              ログイン
-            </Button>
-          </Stack>
-        </form>
-
-        <Divider label="または" labelPosition="center" my="lg" />
-
-        <Stack>
-          <Button
-            leftSection={<IconBrandGoogle size={18} />}
-            onClick={() => handleOAuthSignIn('google')}
-            variant="default"
-          >
-            Googleでログイン
-          </Button>
-          <Button
-            leftSection={<IconBrandDiscord size={18} />}
-            onClick={() => handleOAuthSignIn('discord')}
-            variant="default"
-          >
-            Discordでログイン
-          </Button>
-        </Stack>
-
-        <Text c="dimmed" mt="md" size="sm" ta="center">
-          アカウントをお持ちでないですか？{' '}
-          <Anchor component={Link} href="/auth/register" size="sm">
-            新規登録
-          </Anchor>
-        </Text>
-      </Paper>
-
-      <Button component={Link} href="/" mt="lg" variant="subtle" w="100%">
-        ホームに戻る
-      </Button>
-    </Container>
-  )
-}
-
+/**
+ * Sign-in page with auto-login support for Vercel preview deployments.
+ *
+ * In preview environments with PREVIEW_AUTO_LOGIN_EMAIL and
+ * PREVIEW_AUTO_LOGIN_PASSWORD set, users are automatically redirected
+ * to the auto-login API route. Otherwise, the standard sign-in form
+ * is displayed.
+ */
 export default function SignInPage() {
-  return (
-    <Suspense
-      fallback={
-        <Container py="xl" size="xs">
-          <Text ta="center">読み込み中...</Text>
-        </Container>
-      }
-    >
-      <SignInContent />
-    </Suspense>
-  )
+  const isPreview = process.env.VERCEL_ENV === 'preview'
+  const hasAutoLoginCredentials =
+    process.env.PREVIEW_AUTO_LOGIN_EMAIL &&
+    process.env.PREVIEW_AUTO_LOGIN_PASSWORD
+
+  if (isPreview && hasAutoLoginCredentials) {
+    redirect('/api/auth/auto-login')
+  }
+
+  return <SignInContent />
 }

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -9,14 +9,25 @@ import SignInContent from './SignInContent'
  * PREVIEW_AUTO_LOGIN_PASSWORD set, users are automatically redirected
  * to the auto-login API route. Otherwise, the standard sign-in form
  * is displayed.
+ *
+ * If auto-login previously failed (e.g. account doesn't exist),
+ * the `auto-login-failed` query param prevents re-triggering
+ * the redirect, avoiding an infinite loop.
  */
-export default function SignInPage() {
+export default async function SignInPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}) {
+  const params = await searchParams
+  const autoLoginFailed = params['auto-login-failed']
+
   const isPreview = process.env.VERCEL_ENV === 'preview'
   const hasAutoLoginCredentials =
     process.env.PREVIEW_AUTO_LOGIN_EMAIL &&
     process.env.PREVIEW_AUTO_LOGIN_PASSWORD
 
-  if (isPreview && hasAutoLoginCredentials) {
+  if (isPreview && hasAutoLoginCredentials && !autoLoginFailed) {
     redirect('/api/auth/auto-login')
   }
 

--- a/src/env.js
+++ b/src/env.js
@@ -20,6 +20,9 @@ export const env = createEnv({
     NODE_ENV: z
       .enum(['development', 'test', 'production'])
       .default('development'),
+    // Auto-login for Vercel preview deployments
+    PREVIEW_AUTO_LOGIN_EMAIL: z.string().optional(),
+    PREVIEW_AUTO_LOGIN_PASSWORD: z.string().optional(),
   },
 
   /**
@@ -43,6 +46,8 @@ export const env = createEnv({
     GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
     DATABASE_URL: process.env.DATABASE_URL,
     NODE_ENV: process.env.NODE_ENV,
+    PREVIEW_AUTO_LOGIN_EMAIL: process.env.PREVIEW_AUTO_LOGIN_EMAIL,
+    PREVIEW_AUTO_LOGIN_PASSWORD: process.env.PREVIEW_AUTO_LOGIN_PASSWORD,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially


### PR DESCRIPTION
## Summary
- Vercelプレビューデプロイ環境で、環境変数で指定されたテストアカウントで自動ログインする機能を追加
- PRレビュアーが手動でクレデンシャルを入力する手間を省く
- `VERCEL_ENV !== 'preview'` の場合は完全に無効化（本番・開発環境には影響なし）

## Changes
- `src/env.js`: `PREVIEW_AUTO_LOGIN_EMAIL` / `PREVIEW_AUTO_LOGIN_PASSWORD` 環境変数スキーマを追加
- `src/app/api/auth/auto-login/route.ts`: 自動ログインAPI Route（プレビュー環境のみ動作）
- `src/app/auth/signin/page.tsx`: Server Componentに変換、プレビュー環境判定で自動リダイレクト
- `src/app/auth/signin/SignInContent.tsx`: 既存のClient Componentを分離

## Test plan
- [ ] ローカル環境でサインインページが通常通り表示されることを確認
- [ ] `VERCEL_ENV=preview` + 自動ログイン環境変数設定時にリダイレクトされることを確認
- [ ] 本番環境で `/api/auth/auto-login` が 403 を返すことを確認
- [ ] Vercel プレビュー環境に環境変数を設定して動作確認

Generated with [Claude Code](https://claude.com/claude-code)