### PR TITLE
feat: session list quick filter & BB/BI profit toggle

### DIFF
--- a/src/app/(main)/sessions/SessionsContent.tsx
+++ b/src/app/(main)/sessions/SessionsContent.tsx
@@ -1,12 +1,11 @@
 'use client'
 
-import { Container, Drawer, Group, SegmentedControl, Stack } from '@mantine/core'
+import { Container, Drawer, Stack } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { notifications } from '@mantine/notifications'
 import { useRouter } from 'next/navigation'
 import { useEffect, useMemo, useState, useTransition } from 'react'
 import { usePageTitle } from '~/contexts/PageTitleContext'
-import { GameTypeLabelWithIcon } from '~/components/sessions/GameTypeBadge'
 import {
   type FilterState,
   type NewSessionFormData,
@@ -16,7 +15,6 @@ import {
   SessionList,
   defaultFilters,
   filterSessions,
-  gameTypeOptions,
   hasActiveFilters,
 } from '~/features/sessions'
 import type { RouterOutputs } from '~/trpc/react'
@@ -112,55 +110,10 @@ export function SessionsContent({
           currencies={currencyOptions}
           filters={filters}
           onFiltersChange={setFilters}
+          onProfitUnitChange={setProfitUnit}
+          profitUnit={profitUnit}
           stores={storeOptions}
         />
-
-        <Group gap="sm" justify="space-between">
-          <SegmentedControl
-            data={gameTypeOptions.map((opt) => ({
-              value: opt.value,
-              label:
-                opt.value === 'all' ? (
-                  opt.label
-                ) : (
-                  <GameTypeLabelWithIcon
-                    gameType={opt.value}
-                    iconSize={14}
-                  />
-                ),
-            }))}
-            onChange={(value) =>
-              setFilters((prev) => ({
-                ...prev,
-                gameType: value as FilterState['gameType'],
-              }))
-            }
-            size="xs"
-            value={filters.gameType}
-          />
-          {filters.gameType === 'cash' && (
-            <SegmentedControl
-              data={[
-                { value: 'real', label: '実収支' },
-                { value: 'bb', label: 'BB' },
-              ]}
-              onChange={(value) => setProfitUnit(value as ProfitUnit)}
-              size="xs"
-              value={profitUnit === 'bi' ? 'real' : profitUnit}
-            />
-          )}
-          {filters.gameType === 'tournament' && (
-            <SegmentedControl
-              data={[
-                { value: 'real', label: '実収支' },
-                { value: 'bi', label: 'BI' },
-              ]}
-              onChange={(value) => setProfitUnit(value as ProfitUnit)}
-              size="xs"
-              value={profitUnit === 'bb' ? 'real' : profitUnit}
-            />
-          )}
-        </Group>
 
         <SessionList
           isFiltered={isFiltered}

--- a/src/features/sessions/components/SessionList.tsx
+++ b/src/features/sessions/components/SessionList.tsx
@@ -11,19 +11,37 @@ import { IconCalendar, IconMapPin, IconPlus } from '@tabler/icons-react'
 import Link from 'next/link'
 import { GameTypeBadge } from '~/components/sessions/GameTypeBadge'
 import {
+  formatBBProfitLoss,
+  formatBIProfitLoss,
   formatDate,
   formatDurationShort,
   formatGameName,
   formatProfitLoss,
   getProfitLossColor,
 } from '../lib/format-utils'
-import type { Session } from '../lib/types'
+import type { ProfitUnit, Session } from '../lib/types'
 import { SessionFAB } from './SessionFAB'
 
 interface SessionListProps {
   sessions: Session[]
   isFiltered: boolean
   onOpenNewSession: () => void
+  profitUnit: ProfitUnit
+}
+
+function formatProfit(
+  profitLoss: number | null,
+  session: Session,
+  profitUnit: ProfitUnit,
+): string {
+  switch (profitUnit) {
+    case 'bb':
+      return formatBBProfitLoss(profitLoss, session.cashGame?.bigBlind)
+    case 'bi':
+      return formatBIProfitLoss(profitLoss, session.tournament?.buyIn)
+    default:
+      return formatProfitLoss(profitLoss)
+  }
 }
 
 /**
@@ -35,6 +53,7 @@ export function SessionList({
   sessions,
   isFiltered,
   onOpenNewSession,
+  profitUnit,
 }: SessionListProps) {
   // Empty state
   if (sessions.length === 0) {
@@ -131,7 +150,7 @@ export function SessionList({
                     lh={1.2}
                     size="sm"
                   >
-                    {formatProfitLoss(session.profitLoss)}
+                    {formatProfit(session.profitLoss, session, profitUnit)}
                   </Text>
                   {session.allInSummary &&
                     session.allInSummary.count > 0 &&
@@ -145,9 +164,11 @@ export function SessionList({
                         size="xs"
                       >
                         (EV:{' '}
-                        {formatProfitLoss(
+                        {formatProfit(
                           session.profitLoss -
                             session.allInSummary.evDifference,
+                          session,
+                          profitUnit,
                         )}
                         )
                       </Text>

--- a/src/features/sessions/index.ts
+++ b/src/features/sessions/index.ts
@@ -11,6 +11,7 @@ export type {
   StoreOption,
   CurrencyOption,
   PeriodPreset,
+  ProfitUnit,
 } from './lib/types'
 export type { NewSessionFormData } from './components/NewSessionForm'
 
@@ -26,6 +27,8 @@ export {
   formatTime,
   formatDurationShort,
   formatProfitLoss,
+  formatBBProfitLoss,
+  formatBIProfitLoss,
   getProfitLossColor,
 } from './lib/format-utils'
 export { combineDateAndTime, combineEndDateTime } from './lib/date-utils'

--- a/src/features/sessions/lib/format-utils.ts
+++ b/src/features/sessions/lib/format-utils.ts
@@ -64,6 +64,40 @@ export function formatProfitLoss(profitLoss: number | null): string {
 }
 
 /**
+ * Format profit/loss in BB (Big Blind) units.
+ * Falls back to formatProfitLoss when bigBlind is invalid.
+ */
+export function formatBBProfitLoss(
+  profitLoss: number | null,
+  bigBlind: number | null | undefined,
+): string {
+  if (profitLoss === null) return '-'
+  if (!bigBlind) return formatProfitLoss(profitLoss)
+  const bbValue = profitLoss / bigBlind
+  const formatted = Math.abs(bbValue).toFixed(1)
+  if (bbValue > 0) return `+${formatted} BB`
+  if (bbValue < 0) return `-${formatted} BB`
+  return `${formatted} BB`
+}
+
+/**
+ * Format profit/loss in BI (Buy-In) units.
+ * Falls back to formatProfitLoss when buyIn is invalid.
+ */
+export function formatBIProfitLoss(
+  profitLoss: number | null,
+  buyIn: number | null | undefined,
+): string {
+  if (profitLoss === null) return '-'
+  if (!buyIn) return formatProfitLoss(profitLoss)
+  const biValue = profitLoss / buyIn
+  const formatted = Math.abs(biValue).toFixed(2)
+  if (biValue > 0) return `+${formatted} BI`
+  if (biValue < 0) return `-${formatted} BI`
+  return `${formatted} BI`
+}
+
+/**
  * Get color based on profit/loss.
  */
 export function getProfitLossColor(profitLoss: number | null): string {

--- a/src/features/sessions/lib/types.ts
+++ b/src/features/sessions/lib/types.ts
@@ -34,6 +34,9 @@ export interface CurrencyOption {
   name: string
 }
 
+/** Profit display unit for session list */
+export type ProfitUnit = 'real' | 'bb' | 'bi'
+
 /** Session data structure for list display */
 export interface Session {
   id: string


### PR DESCRIPTION
## Summary
- セッション一覧にゲームタイプのクイックフィルタ（All / Cash / Tournament）を SegmentedControl で追加
- Cash 選択時は「実収支 / BB」、Tournament 選択時は「実収支 / BI」の収支単位トグルを表示
- `formatBBProfitLoss` / `formatBIProfitLoss` ユーティリティ関数を追加し、SessionList の収支表示を対応

## Changes
- `format-utils.ts`: BB/BI フォーマット関数追加
- `types.ts`: `ProfitUnit` 型追加
- `index.ts`: エクスポート更新
- `SessionList.tsx`: `profitUnit` prop 追加、収支表示フォーマット切り替え
- `SessionsContent.tsx`: クイックフィルタ UI + 収支単位トグル追加

## Test plan
- [ ] All / Cash / Tournament フィルタ切り替えでセッション一覧が正しくフィルタリングされること
- [ ] Cash 選択時に「実収支 / BB」トグルが表示され、BB 選択で BB 単位の収支が表示されること
- [ ] Tournament 選択時に「実収支 / BI」トグルが表示され、BI 選択で BI 単位の収支が表示されること
- [ ] All に戻した際に収支単位が「実収支」にリセットされること
- [ ] EV 表示も選択した収支単位に連動すること

Closes SAP-170

🤖 Generated with [Claude Code](https://claude.com/claude-code)